### PR TITLE
Fix AgentActor InvokeAsync options

### DIFF
--- a/dotnet/src/Agents/Orchestration/AgentActor.cs
+++ b/dotnet/src/Agents/Orchestration/AgentActor.cs
@@ -16,7 +16,6 @@ namespace Microsoft.SemanticKernel.Agents.Orchestration;
 /// </summary>
 public abstract class AgentActor : OrchestrationActor
 {
-    private AgentInvokeOptions? _options;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AgentActor"/> class.
@@ -164,7 +163,7 @@ public abstract class AgentActor : OrchestrationActor
         }
     }
 
-    private AgentInvokeOptions GetInvokeOptions(Func<ChatMessageContent, Task> messageHandler) => this._options ??= this.CreateInvokeOptions(messageHandler);
+    private AgentInvokeOptions GetInvokeOptions(Func<ChatMessageContent, Task> messageHandler) => this.CreateInvokeOptions(messageHandler);
 
     private static string VerifyDescription(Agent agent)
     {


### PR DESCRIPTION
## Summary
- fix AgentActor.InvokeAsync to recreate invocation options each call

## Testing
- `bash dotnet/build.sh` *(fails: dotnet command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868d639782883269697f939e59b90ca